### PR TITLE
Add support for todo tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ This is a PHP implementation of <a href="http://search.cpan.org/perldoc?Test::Mo
     pass($test_name);
     fail($test_name);
 
+    todo_begin("New frobaz feature");
+
+    ok( $got, $expected, $test_name );
+    # ...
+
+    todo_end();
+
+    # Or under 5.3
+    todo( "New frobaz feature", function () {
+        ok( $got, $expected, $test_name );
+        # ...
+    } );
+
 
 ## Testing the tests
 

--- a/test/test.php
+++ b/test/test.php
@@ -23,7 +23,7 @@
 		'woo' => 'yay',
 	);
 
-	echo "1..32\n";
+	echo "1..36\n";
 
 
 	#
@@ -80,6 +80,20 @@
 	is_deeply($struct_1, $struct_1, 'is_deeply()');
 	check_capture(true);
 
+	todo_begin("Testing");
+
+	pass("example implemented todo test");
+	check_capture(true);
+
+	todo_end();
+
+        // in 5.3 we would pass an anonymous function
+	function ex_todo_pass() {
+		pass("example todo in subroutine");
+	}
+	todo( "Testing", "ex_todo_pass" );
+	check_capture(true);
+
 
 	#
 	# Expecting these to fail
@@ -133,7 +147,21 @@
 	is_deeply($struct_1, $struct_2, 'is_deeply()');
 	check_capture(false);
 
+	todo_begin("Testing");
 
+	fail("example unimplemented todo test");
+	check_capture(false);
+
+	todo_end();
+
+        // in 5.3 we would pass an anonymous function
+	function ex_todo_fail() {
+		fail("example fail in subroutine");
+	}
+	todo( "Testing", "ex_todo_fail" );
+	check_capture(false);
+
+	
 	$GLOBALS['_no_plan'] = false;
 	$GLOBALS['_num_failures'] = 0;
 
@@ -182,6 +210,7 @@
 
 		$result = array_pop($results);
 		$explain = $result[1] ? " - $result[1]" : '';
+		$explain = preg_replace('!#!','\\#',$explain); # Escape comments, eg, TODOs
 		if ($pass){
 			if ($result[0]){
 				echo "ok $num - pass$explain\n";

--- a/testmore.php
+++ b/testmore.php
@@ -79,11 +79,34 @@ function plan($plan)
     }
 }
 
+function todo($why, $todo_tests) {
+    todo_begin($why);
+    call_user_func($todo_tests);
+    todo_end();
+}
+
+function todo_begin($why="")
+{
+    global $_testmore_todo;
+    if ( ! isset($_testmore_todo) ) {
+        $_testmore_todo = array();
+    }
+    array_push($_testmore_todo,$why);
+}
+
+function todo_end()
+{
+    global $_testmore_todo;
+    assert('is_array($_testmore_todo)');
+    array_pop($_testmore_todo);
+}
+
 function ok($pass, $test_name = '')
 {
     global $_test_num;
     global $_num_failures;
     global $_num_skips;
+    global $_testmore_todo;
 
     $_test_num++; 
 
@@ -94,6 +117,11 @@ function ok($pass, $test_name = '')
 
     if (!empty($test_name) && $test_name[0] != '#') {
         $test_name = "- $test_name";
+    }
+    
+    if ($test_name[0] != '#' and isset($_testmore_todo) and count($_testmore_todo)) {
+        $msg = array_pop( array_values( $_testmore_todo ) );
+        $test_name .= " # TODO $msg";
     }
 
     if ($pass) {
@@ -302,10 +330,6 @@ function is_deeply($got_struct, $expected_struct, $test_name = '')
 /*
 
 TODO:
-
-function todo()
-{
-}
 
 function todo_skip()
 {


### PR DESCRIPTION
That is, tests that are expected to fail as the feature they are testing is not implemented yet.

This provides two mechanisms, one that's more 5.2 friendly:

```
todo_begin("reason");

# tests

todo_end();
```

and one that's more 5.3 friendly:

```
todo("reason", function () {
    # tests
} );
```
