### PR TITLE
Add a test name to include_ok and require_ok

### DIFF
--- a/testmore.php
+++ b/testmore.php
@@ -266,13 +266,13 @@ function diag($message)
 function include_ok($module)
 {
     $pass = ((include $module) == 1);
-    return ok($pass);
+    return ok($pass, "include $module");
 }
 
 function require_ok($module)
 {
     $pass = ((require $module) == 1);
-    return ok($pass);
+    return ok($pass, "require $module");
 } 
 
 function skip($message, $num)


### PR DESCRIPTION
In the spirit of Perl's Test::More, this adds a test name to require_ok and include_ok.
